### PR TITLE
Add backup destinations & backup schedules

### DIFF
--- a/app/Http/Controllers/BackupDestinationController.php
+++ b/app/Http/Controllers/BackupDestinationController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\BackupDestinations\StoreBackupDestinationRequest;
+use App\Models\BackupDestination;
+use App\Services\ServerNameGenerator;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class BackupDestinationController extends Controller
+{
+    public function generateName(ServerNameGenerator $generator): JsonResponse
+    {
+        return response()->json([
+            'name' => $generator->generate(),
+        ]);
+    }
+
+    public function index(Request $request): Response
+    {
+        $destinations = $request->user()
+            ->backupDestinations()
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn (BackupDestination $destination) => [
+                'id' => $destination->id,
+                'name' => $destination->name,
+                'type' => $destination->type,
+                'host' => $destination->host,
+                'port' => $destination->port,
+                'username' => $destination->username,
+                'storage_path' => $destination->storage_path,
+                'status' => $destination->status,
+                'last_connected_at' => $destination->last_connected_at?->toIso8601String(),
+                'created_at' => $destination->created_at->toIso8601String(),
+            ]);
+
+        return Inertia::render('backup-destinations/Index', [
+            'destinations' => $destinations,
+        ]);
+    }
+
+    public function store(StoreBackupDestinationRequest $request): RedirectResponse
+    {
+        $destination = $request->user()->backupDestinations()->create($request->validated());
+
+        return redirect()->route('backup-destinations.show', $destination);
+    }
+
+    public function show(Request $request, BackupDestination $backupDestination): Response
+    {
+        abort_unless($backupDestination->user_id === $request->user()->id, 403);
+
+        $schedules = $backupDestination->backupSchedules()
+            ->with('server')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn ($schedule) => [
+                'id' => $schedule->id,
+                'server_name' => $schedule->server->name,
+                'server_id' => $schedule->server_id,
+                'frequency' => $schedule->frequency,
+                'time' => $schedule->time,
+                'day_of_week' => $schedule->day_of_week,
+                'day_of_month' => $schedule->day_of_month,
+                'retention_count' => $schedule->retention_count,
+                'is_enabled' => $schedule->is_enabled,
+                'created_at' => $schedule->created_at->toIso8601String(),
+            ]);
+
+        return Inertia::render('backup-destinations/Show', [
+            'destination' => [
+                'id' => $backupDestination->id,
+                'name' => $backupDestination->name,
+                'type' => $backupDestination->type,
+                'host' => $backupDestination->host,
+                'port' => $backupDestination->port,
+                'username' => $backupDestination->username,
+                'auth_method' => $backupDestination->auth_method,
+                'storage_path' => $backupDestination->storage_path,
+                'status' => $backupDestination->status,
+                'last_connected_at' => $backupDestination->last_connected_at?->toIso8601String(),
+                'created_at' => $backupDestination->created_at->toIso8601String(),
+            ],
+            'schedules' => $schedules,
+        ]);
+    }
+
+    public function destroy(Request $request, BackupDestination $backupDestination): RedirectResponse
+    {
+        abort_unless($backupDestination->user_id === $request->user()->id, 403);
+
+        $backupDestination->delete();
+
+        return redirect()->route('backup-destinations.index');
+    }
+}

--- a/app/Http/Controllers/BackupScheduleController.php
+++ b/app/Http/Controllers/BackupScheduleController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\BackupSchedules\StoreBackupScheduleRequest;
+use App\Models\BackupSchedule;
+use App\Models\Server;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class BackupScheduleController extends Controller
+{
+    public function store(StoreBackupScheduleRequest $request, Server $server): RedirectResponse
+    {
+        abort_unless($server->user_id === $request->user()->id, 403);
+
+        $server->backupSchedules()->create($request->validated());
+
+        return redirect()->route('servers.show', $server);
+    }
+
+    public function destroy(Request $request, Server $server, BackupSchedule $backupSchedule): RedirectResponse
+    {
+        abort_unless($server->user_id === $request->user()->id, 403);
+        abort_unless($backupSchedule->server_id === $server->id, 404);
+
+        $backupSchedule->delete();
+
+        return redirect()->route('servers.show', $server);
+    }
+}

--- a/app/Http/Controllers/BackupScheduleIndexController.php
+++ b/app/Http/Controllers/BackupScheduleIndexController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class BackupScheduleIndexController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $schedules = $request->user()
+            ->servers()
+            ->with(['backupSchedules.backupDestination'])
+            ->get()
+            ->flatMap(fn ($server) => $server->backupSchedules->map(fn ($schedule) => [
+                'id' => $schedule->id,
+                'server_id' => $server->id,
+                'server_name' => $server->name,
+                'destination_name' => $schedule->backupDestination->name,
+                'frequency' => $schedule->frequency,
+                'time' => $schedule->time,
+                'day_of_week' => $schedule->day_of_week,
+                'day_of_month' => $schedule->day_of_month,
+                'retention_count' => $schedule->retention_count,
+                'is_enabled' => $schedule->is_enabled,
+                'created_at' => $schedule->created_at->toIso8601String(),
+            ]))
+            ->sortByDesc('created_at')
+            ->values();
+
+        return Inertia::render('backup-schedules/Index', [
+            'schedules' => $schedules,
+        ]);
+    }
+}

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\Servers\StoreServerRequest;
 use App\Http\Resources\ServerResource;
+use App\Models\BackupDestination;
 use App\Models\Server;
 use App\Services\ServerNameGenerator;
 use Illuminate\Http\JsonResponse;
@@ -58,11 +59,39 @@ class ServerController extends Controller
             $provisionUrl,
         );
 
+        $backupSchedules = $server->backupSchedules()
+            ->with('backupDestination')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn ($schedule) => [
+                'id' => $schedule->id,
+                'backup_destination_id' => $schedule->backup_destination_id,
+                'destination_name' => $schedule->backupDestination->name,
+                'frequency' => $schedule->frequency,
+                'time' => $schedule->time,
+                'day_of_week' => $schedule->day_of_week,
+                'day_of_month' => $schedule->day_of_month,
+                'retention_count' => $schedule->retention_count,
+                'is_enabled' => $schedule->is_enabled,
+                'created_at' => $schedule->created_at->toIso8601String(),
+            ]);
+
+        $backupDestinations = $request->user()
+            ->backupDestinations()
+            ->orderBy('name')
+            ->get()
+            ->map(fn (BackupDestination $d) => [
+                'id' => $d->id,
+                'name' => $d->name,
+            ]);
+
         return Inertia::render('servers/Show', [
             'server' => array_merge((new ServerResource($server))->resolve(), [
                 'callback_signature' => $server->callback_signature,
                 'wget_command' => $wgetCommand,
             ]),
+            'backupSchedules' => $backupSchedules,
+            'backupDestinations' => $backupDestinations,
         ]);
     }
 

--- a/app/Http/Requests/BackupDestinations/StoreBackupDestinationRequest.php
+++ b/app/Http/Requests/BackupDestinations/StoreBackupDestinationRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests\BackupDestinations;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreBackupDestinationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'type' => ['required', 'string', 'in:borg'],
+            'host' => ['required', 'string', 'max:255'],
+            'port' => ['required', 'integer', 'min:1', 'max:65535'],
+            'username' => ['required', 'string', 'max:255'],
+            'auth_method' => ['required', 'string', 'in:password,ssh_key'],
+            'password' => ['nullable', 'required_if:auth_method,password', 'string'],
+            'ssh_private_key' => ['nullable', 'required_if:auth_method,ssh_key', 'string'],
+            'storage_path' => ['required', 'string', 'max:255'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'Give your backup destination a name.',
+            'host.required' => 'A host address is required.',
+            'username.required' => 'A username is required.',
+            'password.required_if' => 'A password is required when using password authentication.',
+            'ssh_private_key.required_if' => 'An SSH private key is required when using SSH key authentication.',
+            'storage_path.required' => 'A storage path is required.',
+        ];
+    }
+}

--- a/app/Http/Requests/BackupSchedules/StoreBackupScheduleRequest.php
+++ b/app/Http/Requests/BackupSchedules/StoreBackupScheduleRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests\BackupSchedules;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreBackupScheduleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $userId = $this->user()->id;
+
+        return [
+            'backup_destination_id' => [
+                'required',
+                'integer',
+                Rule::exists('backup_destinations', 'id')->where('user_id', $userId),
+            ],
+            'frequency' => ['required', 'string', 'in:daily,weekly,monthly'],
+            'time' => ['required', 'date_format:H:i'],
+            'day_of_week' => ['nullable', 'required_if:frequency,weekly', 'integer', 'min:0', 'max:6'],
+            'day_of_month' => ['nullable', 'required_if:frequency,monthly', 'integer', 'min:1', 'max:28'],
+            'retention_count' => ['required', 'integer', 'min:1', 'max:365'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'backup_destination_id.required' => 'Please select a backup destination.',
+            'backup_destination_id.exists' => 'The selected backup destination is invalid.',
+            'frequency.required' => 'Please select a backup frequency.',
+            'time.required' => 'Please specify a backup time.',
+            'time.date_format' => 'Time must be in HH:MM format.',
+            'day_of_week.required_if' => 'Please select a day of the week for weekly backups.',
+            'day_of_month.required_if' => 'Please select a day of the month for monthly backups.',
+        ];
+    }
+}

--- a/app/Models/BackupDestination.php
+++ b/app/Models/BackupDestination.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\BackupDestinationFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable([
+    'user_id',
+    'name',
+    'type',
+    'host',
+    'port',
+    'username',
+    'auth_method',
+    'password',
+    'ssh_private_key',
+    'storage_path',
+    'status',
+    'last_connected_at',
+])]
+class BackupDestination extends Model
+{
+    /** @use HasFactory<BackupDestinationFactory> */
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'port' => 'integer',
+            'password' => 'encrypted',
+            'ssh_private_key' => 'encrypted',
+            'last_connected_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return HasMany<BackupSchedule, $this> */
+    public function backupSchedules(): HasMany
+    {
+        return $this->hasMany(BackupSchedule::class);
+    }
+}

--- a/app/Models/BackupSchedule.php
+++ b/app/Models/BackupSchedule.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\BackupScheduleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'server_id',
+    'backup_destination_id',
+    'frequency',
+    'time',
+    'day_of_week',
+    'day_of_month',
+    'retention_count',
+    'is_enabled',
+])]
+class BackupSchedule extends Model
+{
+    /** @use HasFactory<BackupScheduleFactory> */
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'day_of_week' => 'integer',
+            'day_of_month' => 'integer',
+            'retention_count' => 'integer',
+            'is_enabled' => 'boolean',
+        ];
+    }
+
+    public function server(): BelongsTo
+    {
+        return $this->belongsTo(Server::class);
+    }
+
+    public function backupDestination(): BelongsTo
+    {
+        return $this->belongsTo(BackupDestination::class);
+    }
+}

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use phpseclib3\Crypt\EC;
 
@@ -78,6 +79,12 @@ class Server extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /** @return HasMany<BackupSchedule, $this> */
+    public function backupSchedules(): HasMany
+    {
+        return $this->hasMany(BackupSchedule::class);
     }
 
     public function isProvisioning(): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -39,6 +39,12 @@ class User extends Authenticatable
         return $this->hasMany(Server::class);
     }
 
+    /** @return HasMany<BackupDestination, $this> */
+    public function backupDestinations(): HasMany
+    {
+        return $this->hasMany(BackupDestination::class);
+    }
+
     /** @return HasMany<Site, $this> */
     public function sites(): HasMany
     {

--- a/database/factories/BackupDestinationFactory.php
+++ b/database/factories/BackupDestinationFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BackupDestination;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<BackupDestination>
+ */
+class BackupDestinationFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => $this->faker->words(2, true).' backup',
+            'type' => 'borg',
+            'host' => $this->faker->ipv4(),
+            'port' => 22,
+            'username' => $this->faker->userName(),
+            'auth_method' => 'password',
+            'password' => $this->faker->password(),
+            'ssh_private_key' => null,
+            'storage_path' => '/backups',
+            'status' => 'pending',
+            'last_connected_at' => null,
+        ];
+    }
+
+    public function sshKey(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'auth_method' => 'ssh_key',
+            'password' => null,
+            'ssh_private_key' => 'fake-ssh-private-key',
+        ]);
+    }
+}

--- a/database/factories/BackupScheduleFactory.php
+++ b/database/factories/BackupScheduleFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BackupDestination;
+use App\Models\BackupSchedule;
+use App\Models\Server;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<BackupSchedule>
+ */
+class BackupScheduleFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'server_id' => Server::factory(),
+            'backup_destination_id' => BackupDestination::factory(),
+            'frequency' => $this->faker->randomElement(['daily', 'weekly', 'monthly']),
+            'time' => $this->faker->time('H:i'),
+            'day_of_week' => null,
+            'day_of_month' => null,
+            'retention_count' => 7,
+            'is_enabled' => true,
+        ];
+    }
+
+    public function weekly(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'frequency' => 'weekly',
+            'day_of_week' => $this->faker->numberBetween(0, 6),
+        ]);
+    }
+
+    public function monthly(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'frequency' => 'monthly',
+            'day_of_month' => $this->faker->numberBetween(1, 28),
+        ]);
+    }
+}

--- a/database/migrations/2026_03_20_000001_create_backup_destinations_table.php
+++ b/database/migrations/2026_03_20_000001_create_backup_destinations_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('backup_destinations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('type')->default('borg');
+            $table->string('host');
+            $table->unsignedSmallInteger('port')->default(22);
+            $table->string('username');
+            $table->string('auth_method');
+            $table->text('password')->nullable();
+            $table->text('ssh_private_key')->nullable();
+            $table->string('storage_path');
+            $table->string('status')->default('pending');
+            $table->timestamp('last_connected_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('backup_destinations');
+    }
+};

--- a/database/migrations/2026_03_20_000002_create_backup_schedules_table.php
+++ b/database/migrations/2026_03_20_000002_create_backup_schedules_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('backup_schedules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('server_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('backup_destination_id')->constrained()->cascadeOnDelete();
+            $table->string('frequency');
+            $table->string('time');
+            $table->unsignedTinyInteger('day_of_week')->nullable();
+            $table->unsignedTinyInteger('day_of_month')->nullable();
+            $table->unsignedInteger('retention_count')->default(7);
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('backup_schedules');
+    }
+};

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
 import {
+    CalendarClock,
+    Database,
     FolderGit2,
     Server,
 } from 'lucide-vue-next';
@@ -17,14 +19,29 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
+import { index as backupDestinationsIndex } from '@/routes/backup-destinations';
+import { index as backupSchedulesIndex } from '@/routes/backup-schedules';
 import { index as serversIndex } from '@/routes/servers';
 import type { NavItem } from '@/types';
 
-const mainNavItems: NavItem[] = [
+const platformNavItems: NavItem[] = [
     {
         title: 'Servers',
         href: serversIndex(),
         icon: Server,
+    },
+];
+
+const backupsNavItems: NavItem[] = [
+    {
+        title: 'Destinations',
+        href: backupDestinationsIndex(),
+        icon: Database,
+    },
+    {
+        title: 'Schedules',
+        href: backupSchedulesIndex(),
+        icon: CalendarClock,
     },
 ];
 
@@ -52,7 +69,8 @@ const footerNavItems: NavItem[] = [
         </SidebarHeader>
 
         <SidebarContent>
-            <NavMain :items="mainNavItems" />
+            <NavMain label="Platform" :items="platformNavItems" />
+            <NavMain label="Backups" :items="backupsNavItems" />
         </SidebarContent>
 
         <SidebarFooter>

--- a/resources/js/components/NavMain.vue
+++ b/resources/js/components/NavMain.vue
@@ -11,6 +11,7 @@ import { useCurrentUrl } from '@/composables/useCurrentUrl';
 import type { NavItem } from '@/types';
 
 defineProps<{
+    label: string;
     items: NavItem[];
 }>();
 
@@ -19,7 +20,7 @@ const { isCurrentUrl } = useCurrentUrl();
 
 <template>
     <SidebarGroup class="px-2 py-0">
-        <SidebarGroupLabel>Platform</SidebarGroupLabel>
+        <SidebarGroupLabel>{{ label }}</SidebarGroupLabel>
         <SidebarMenu>
             <SidebarMenuItem v-for="item in items" :key="item.title">
                 <SidebarMenuButton

--- a/resources/js/pages/backup-destinations/Index.vue
+++ b/resources/js/pages/backup-destinations/Index.vue
@@ -1,0 +1,329 @@
+<script setup lang="ts">
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import {
+    HardDrive,
+    Plus,
+    ChevronRight,
+    Loader2,
+} from 'lucide-vue-next';
+import { ref, watch } from 'vue';
+import InputError from '@/components/InputError.vue';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import AppLayout from '@/layouts/AppLayout.vue';
+import {
+    index as destinationsIndex,
+    store as destinationsStore,
+    show as destinationsShow,
+    generateName as destinationsGenerateName,
+} from '@/routes/backup-destinations';
+import type { BreadcrumbItem } from '@/types';
+
+interface DestinationRow {
+    id: number;
+    name: string;
+    type: string;
+    host: string;
+    port: number;
+    username: string;
+    storage_path: string;
+    status: string;
+    last_connected_at: string | null;
+    created_at: string;
+}
+
+const props = defineProps<{
+    destinations: DestinationRow[];
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Backup Destinations', href: destinationsIndex() },
+];
+
+const showAddModal = ref(false);
+
+watch(showAddModal, async (open) => {
+    if (!open) {
+return;
+}
+
+    try {
+        const response = await fetch(destinationsGenerateName.url());
+        const data = await response.json();
+        form.name = data.name;
+    } catch {
+        // silently ignore; user can type manually
+    }
+});
+
+const form = useForm({
+    name: '',
+    type: 'borg',
+    host: '',
+    port: 22,
+    username: '',
+    auth_method: 'password',
+    password: '',
+    ssh_private_key: '',
+    storage_path: '/backups',
+});
+
+function submitAdd() {
+    form.post(destinationsStore(), {
+        onSuccess: () => {
+            showAddModal.value = false;
+            form.reset();
+        },
+    });
+}
+
+function statusVariant(
+    status: string,
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+    switch (status) {
+        case 'connected':
+            return 'default';
+        case 'pending':
+            return 'outline';
+        case 'error':
+            return 'destructive';
+        default:
+            return 'secondary';
+    }
+}
+</script>
+
+<template>
+    <Head title="Backup Destinations" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="flex h-full flex-1 flex-col gap-6 p-6">
+            <!-- Header -->
+            <div class="flex items-center justify-between">
+                <div>
+                    <h1 class="text-2xl font-semibold tracking-tight">
+                        Backup Destinations
+                    </h1>
+                    <p class="mt-1 text-sm text-muted-foreground">
+                        Manage where your server backups are stored.
+                    </p>
+                </div>
+                <Button @click="showAddModal = true">
+                    <Plus class="size-4" />
+                    Add Destination
+                </Button>
+            </div>
+
+            <!-- Empty state -->
+            <div
+                v-if="props.destinations.length === 0"
+                class="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-sidebar-border/70 py-20 dark:border-sidebar-border"
+            >
+                <div class="rounded-full bg-muted p-4">
+                    <HardDrive class="size-8 text-muted-foreground" />
+                </div>
+                <div class="text-center">
+                    <p class="font-medium">No backup destinations yet</p>
+                    <p class="mt-1 text-sm text-muted-foreground">
+                        Add your first backup destination to get started.
+                    </p>
+                </div>
+                <Button @click="showAddModal = true" variant="outline">
+                    <Plus class="size-4" />
+                    Add Destination
+                </Button>
+            </div>
+
+            <!-- Destination list -->
+            <div v-else class="flex flex-col gap-2">
+                <Link
+                    v-for="destination in props.destinations"
+                    :key="destination.id"
+                    :href="destinationsShow(destination.id)"
+                    class="group flex items-center justify-between rounded-xl border border-sidebar-border/70 bg-card px-5 py-4 transition-colors hover:bg-accent dark:border-sidebar-border"
+                >
+                    <div class="flex items-center gap-4">
+                        <div class="rounded-lg bg-muted p-2">
+                            <HardDrive class="size-5 text-muted-foreground" />
+                        </div>
+                        <div>
+                            <p class="leading-none font-medium">
+                                {{ destination.name }}
+                            </p>
+                            <p class="mt-1 text-sm text-muted-foreground">
+                                {{ destination.username }}@{{ destination.host }}:{{ destination.port }}
+                                <span class="mx-1.5">·</span>
+                                {{ destination.storage_path }}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <Badge :variant="statusVariant(destination.status)" class="capitalize">
+                            {{ destination.status }}
+                        </Badge>
+                        <ChevronRight
+                            class="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                        />
+                    </div>
+                </Link>
+            </div>
+        </div>
+
+        <!-- Add Destination Modal -->
+        <Dialog v-model:open="showAddModal">
+            <DialogContent class="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>Add Backup Destination</DialogTitle>
+                    <DialogDescription>
+                        Configure a remote storage location for your backups.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <form
+                    @submit.prevent="submitAdd"
+                    class="flex flex-col gap-4 py-2"
+                >
+                    <div class="flex flex-col gap-1.5">
+                        <label class="text-sm font-medium" for="dest-name"
+                            >Name</label
+                        >
+                        <Input
+                            id="dest-name"
+                            v-model="form.name"
+                            placeholder="e.g. Hetzner Storage Box"
+                            :disabled="form.processing"
+                        />
+                        <InputError :message="form.errors.name" />
+                    </div>
+
+                    <div class="grid grid-cols-2 gap-4">
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium" for="dest-host"
+                                >Host</label
+                            >
+                            <Input
+                                id="dest-host"
+                                v-model="form.host"
+                                placeholder="e.g. u123456.your-storagebox.de"
+                                :disabled="form.processing"
+                            />
+                            <InputError :message="form.errors.host" />
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium" for="dest-port"
+                                >Port</label
+                            >
+                            <Input
+                                id="dest-port"
+                                v-model.number="form.port"
+                                type="number"
+                                min="1"
+                                max="65535"
+                                :disabled="form.processing"
+                            />
+                            <InputError :message="form.errors.port" />
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-1.5">
+                        <label class="text-sm font-medium" for="dest-username"
+                            >Username</label
+                        >
+                        <Input
+                            id="dest-username"
+                            v-model="form.username"
+                            placeholder="e.g. u123456"
+                            :disabled="form.processing"
+                        />
+                        <InputError :message="form.errors.username" />
+                    </div>
+
+                    <div class="flex flex-col gap-1.5">
+                        <label class="text-sm font-medium" for="dest-auth-method"
+                            >Authentication method</label
+                        >
+                        <select
+                            id="dest-auth-method"
+                            v-model="form.auth_method"
+                            :disabled="form.processing"
+                            class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            <option value="password">Password</option>
+                            <option value="ssh_key">SSH Key</option>
+                        </select>
+                        <InputError :message="form.errors.auth_method" />
+                    </div>
+
+                    <div v-if="form.auth_method === 'password'" class="flex flex-col gap-1.5">
+                        <label class="text-sm font-medium" for="dest-password"
+                            >Password</label
+                        >
+                        <Input
+                            id="dest-password"
+                            v-model="form.password"
+                            type="password"
+                            :disabled="form.processing"
+                        />
+                        <InputError :message="form.errors.password" />
+                    </div>
+
+                    <div v-if="form.auth_method === 'ssh_key'" class="flex flex-col gap-1.5">
+                        <label class="text-sm font-medium" for="dest-ssh-key"
+                            >SSH Private Key</label
+                        >
+                        <textarea
+                            id="dest-ssh-key"
+                            v-model="form.ssh_private_key"
+                            :disabled="form.processing"
+                            rows="4"
+                            class="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                            placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
+                        ></textarea>
+                        <InputError :message="form.errors.ssh_private_key" />
+                    </div>
+
+                    <div class="flex flex-col gap-1.5">
+                        <label class="text-sm font-medium" for="dest-storage-path"
+                            >Storage path</label
+                        >
+                        <Input
+                            id="dest-storage-path"
+                            v-model="form.storage_path"
+                            placeholder="e.g. /backups"
+                            :disabled="form.processing"
+                        />
+                        <InputError :message="form.errors.storage_path" />
+                    </div>
+
+                    <DialogFooter class="pt-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            @click="showAddModal = false"
+                            :disabled="form.processing"
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" :disabled="form.processing">
+                            <Loader2
+                                v-if="form.processing"
+                                class="size-4 animate-spin"
+                            />
+                            Create Destination
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    </AppLayout>
+</template>

--- a/resources/js/pages/backup-destinations/Show.vue
+++ b/resources/js/pages/backup-destinations/Show.vue
@@ -1,0 +1,251 @@
+<script setup lang="ts">
+import { Head, useForm } from '@inertiajs/vue3';
+import {
+    HardDrive,
+    Trash2,
+    Loader2,
+    Calendar,
+} from 'lucide-vue-next';
+import { ref } from 'vue';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+    DialogClose,
+} from '@/components/ui/dialog';
+import AppLayout from '@/layouts/AppLayout.vue';
+import {
+    index as destinationsIndex,
+    show as destinationsShow,
+    destroy as destinationsDestroy,
+} from '@/routes/backup-destinations';
+import type { BreadcrumbItem } from '@/types';
+
+interface DestinationDetail {
+    id: number;
+    name: string;
+    type: string;
+    host: string;
+    port: number;
+    username: string;
+    auth_method: string;
+    storage_path: string;
+    status: string;
+    last_connected_at: string | null;
+    created_at: string;
+}
+
+interface ScheduleRow {
+    id: number;
+    server_name: string;
+    server_id: number;
+    frequency: string;
+    time: string;
+    day_of_week: number | null;
+    day_of_month: number | null;
+    retention_count: number;
+    is_enabled: boolean;
+    created_at: string;
+}
+
+const props = defineProps<{
+    destination: DestinationDetail;
+    schedules: ScheduleRow[];
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Backup Destinations', href: destinationsIndex() },
+    { title: props.destination.name, href: destinationsShow(props.destination.id) },
+];
+
+function statusVariant(
+    status: string,
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+    switch (status) {
+        case 'connected':
+            return 'default';
+        case 'pending':
+            return 'outline';
+        case 'error':
+            return 'destructive';
+        default:
+            return 'secondary';
+    }
+}
+
+const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function scheduleLabel(schedule: ScheduleRow): string {
+    if (schedule.frequency === 'weekly' && schedule.day_of_week !== null) {
+        return `Weekly on ${dayNames[schedule.day_of_week]} at ${schedule.time}`;
+    }
+
+    if (schedule.frequency === 'monthly' && schedule.day_of_month !== null) {
+        return `Monthly on day ${schedule.day_of_month} at ${schedule.time}`;
+    }
+
+    return `Daily at ${schedule.time}`;
+}
+
+// ── Delete destination ────────────────────────────────────────
+const showDeleteDialog = ref(false);
+const deleteForm = useForm({});
+
+function deleteDestination() {
+    deleteForm.delete(destinationsDestroy(props.destination.id).url, {
+        onSuccess: () => {
+            showDeleteDialog.value = false;
+        },
+    });
+}
+</script>
+
+<template>
+    <Head :title="destination.name" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div
+            class="mx-auto flex h-full w-full max-w-4xl flex-1 flex-col gap-6 p-6"
+        >
+            <!-- Header -->
+            <div class="flex items-start justify-between gap-4">
+                <div class="flex items-center gap-4">
+                    <div class="rounded-xl bg-muted p-3">
+                        <HardDrive class="size-6 text-muted-foreground" />
+                    </div>
+                    <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">
+                            {{ destination.name }}
+                        </h1>
+                        <div
+                            class="mt-1 flex items-center gap-2 text-sm text-muted-foreground"
+                        >
+                            <span>{{ destination.username }}@{{ destination.host }}:{{ destination.port }}</span>
+                            <span>·</span>
+                            <span>{{ destination.storage_path }}</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="flex items-center gap-2">
+                    <Badge :variant="statusVariant(destination.status)" class="mt-1 capitalize">
+                        {{ destination.status }}
+                    </Badge>
+
+                    <Dialog v-model:open="showDeleteDialog">
+                        <DialogTrigger as-child>
+                            <Button variant="ghost" size="icon" class="mt-1 text-muted-foreground hover:text-destructive">
+                                <Trash2 class="size-4" />
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                            <DialogHeader>
+                                <DialogTitle>Delete backup destination</DialogTitle>
+                                <DialogDescription>
+                                    Are you sure you want to delete <strong>{{ destination.name }}</strong>? All associated backup schedules will also be removed. This action cannot be undone.
+                                </DialogDescription>
+                            </DialogHeader>
+                            <DialogFooter>
+                                <DialogClose as-child>
+                                    <Button variant="outline">Cancel</Button>
+                                </DialogClose>
+                                <Button
+                                    variant="destructive"
+                                    :disabled="deleteForm.processing"
+                                    @click="deleteDestination"
+                                >
+                                    <Loader2 v-if="deleteForm.processing" class="size-4 animate-spin" />
+                                    Delete destination
+                                </Button>
+                            </DialogFooter>
+                        </DialogContent>
+                    </Dialog>
+                </div>
+            </div>
+
+            <!-- Details card -->
+            <div
+                class="overflow-hidden rounded-xl border border-sidebar-border/70 bg-card dark:border-sidebar-border"
+            >
+                <div
+                    class="flex items-center gap-3 border-b border-sidebar-border/70 px-5 py-4 dark:border-sidebar-border"
+                >
+                    <HardDrive class="size-5 shrink-0 text-muted-foreground" />
+                    <p class="text-sm font-medium">Connection Details</p>
+                </div>
+                <div class="grid grid-cols-2 gap-4 p-5">
+                    <div>
+                        <p class="text-xs text-muted-foreground">Type</p>
+                        <p class="mt-0.5 text-sm font-medium uppercase">{{ destination.type }}</p>
+                    </div>
+                    <div>
+                        <p class="text-xs text-muted-foreground">Authentication</p>
+                        <p class="mt-0.5 text-sm font-medium capitalize">{{ destination.auth_method.replace('_', ' ') }}</p>
+                    </div>
+                    <div>
+                        <p class="text-xs text-muted-foreground">Host</p>
+                        <p class="mt-0.5 text-sm font-medium">{{ destination.host }}:{{ destination.port }}</p>
+                    </div>
+                    <div>
+                        <p class="text-xs text-muted-foreground">Username</p>
+                        <p class="mt-0.5 text-sm font-medium">{{ destination.username }}</p>
+                    </div>
+                    <div>
+                        <p class="text-xs text-muted-foreground">Storage Path</p>
+                        <p class="mt-0.5 text-sm font-medium">{{ destination.storage_path }}</p>
+                    </div>
+                    <div>
+                        <p class="text-xs text-muted-foreground">Last Connected</p>
+                        <p class="mt-0.5 text-sm font-medium">
+                            {{ destination.last_connected_at ? new Date(destination.last_connected_at).toLocaleString() : 'Never' }}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Schedules using this destination -->
+            <div
+                class="overflow-hidden rounded-xl border border-sidebar-border/70 bg-card dark:border-sidebar-border"
+            >
+                <div
+                    class="flex items-center gap-3 border-b border-sidebar-border/70 px-5 py-4 dark:border-sidebar-border"
+                >
+                    <Calendar class="size-5 shrink-0 text-muted-foreground" />
+                    <p class="text-sm font-medium">Backup Schedules</p>
+                    <span class="ml-auto text-xs text-muted-foreground">
+                        {{ schedules.length }} schedule{{ schedules.length !== 1 ? 's' : '' }}
+                    </span>
+                </div>
+
+                <div v-if="schedules.length === 0" class="px-5 py-8 text-center text-sm text-muted-foreground">
+                    No servers are using this backup destination yet.
+                </div>
+
+                <div v-else class="divide-y divide-sidebar-border/50 dark:divide-sidebar-border/30">
+                    <div
+                        v-for="schedule in schedules"
+                        :key="schedule.id"
+                        class="flex items-center justify-between px-5 py-3"
+                    >
+                        <div>
+                            <p class="text-sm font-medium">{{ schedule.server_name }}</p>
+                            <p class="mt-0.5 text-xs text-muted-foreground">
+                                {{ scheduleLabel(schedule) }}
+                                <span class="mx-1.5">·</span>
+                                Retain {{ schedule.retention_count }} backups
+                            </p>
+                        </div>
+                        <Badge :variant="schedule.is_enabled ? 'default' : 'outline'">
+                            {{ schedule.is_enabled ? 'Enabled' : 'Disabled' }}
+                        </Badge>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/pages/backup-schedules/Index.vue
+++ b/resources/js/pages/backup-schedules/Index.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { Head, Link } from '@inertiajs/vue3';
+import {
+    CalendarClock,
+    ChevronRight,
+} from 'lucide-vue-next';
+import { Badge } from '@/components/ui/badge';
+import AppLayout from '@/layouts/AppLayout.vue';
+import { show as serversShow } from '@/routes/servers';
+import type { BreadcrumbItem } from '@/types';
+
+interface ScheduleRow {
+    id: number;
+    server_id: number;
+    server_name: string;
+    destination_name: string;
+    frequency: string;
+    time: string;
+    day_of_week: number | null;
+    day_of_month: number | null;
+    retention_count: number;
+    is_enabled: boolean;
+    created_at: string;
+}
+
+const props = defineProps<{
+    schedules: ScheduleRow[];
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Backup Schedules', href: '/backup-schedules' },
+];
+
+const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function scheduleLabel(schedule: ScheduleRow): string {
+    if (schedule.frequency === 'weekly' && schedule.day_of_week !== null) {
+        return `Weekly on ${dayNames[schedule.day_of_week]} at ${schedule.time}`;
+    }
+
+    if (schedule.frequency === 'monthly' && schedule.day_of_month !== null) {
+        return `Monthly on day ${schedule.day_of_month} at ${schedule.time}`;
+    }
+
+    return `Daily at ${schedule.time}`;
+}
+</script>
+
+<template>
+    <Head title="Backup Schedules" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="flex h-full flex-1 flex-col gap-6 p-6">
+            <!-- Header -->
+            <div class="flex items-center justify-between">
+                <div>
+                    <h1 class="text-2xl font-semibold tracking-tight">
+                        Backup Schedules
+                    </h1>
+                    <p class="mt-1 text-sm text-muted-foreground">
+                        All scheduled backups across your servers.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Empty state -->
+            <div
+                v-if="props.schedules.length === 0"
+                class="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-sidebar-border/70 py-20 dark:border-sidebar-border"
+            >
+                <div class="rounded-full bg-muted p-4">
+                    <CalendarClock class="size-8 text-muted-foreground" />
+                </div>
+                <div class="text-center">
+                    <p class="font-medium">No backup schedules yet</p>
+                    <p class="mt-1 text-sm text-muted-foreground">
+                        Add backup schedules from a server's detail page.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Schedule list -->
+            <div v-else class="flex flex-col gap-2">
+                <Link
+                    v-for="schedule in props.schedules"
+                    :key="schedule.id"
+                    :href="serversShow(schedule.server_id)"
+                    class="group flex items-center justify-between rounded-xl border border-sidebar-border/70 bg-card px-5 py-4 transition-colors hover:bg-accent dark:border-sidebar-border"
+                >
+                    <div class="flex items-center gap-4">
+                        <div class="rounded-lg bg-muted p-2">
+                            <CalendarClock class="size-5 text-muted-foreground" />
+                        </div>
+                        <div>
+                            <p class="leading-none font-medium">
+                                {{ schedule.server_name }}
+                            </p>
+                            <p class="mt-1 text-sm text-muted-foreground">
+                                {{ schedule.destination_name }}
+                                <span class="mx-1.5">·</span>
+                                {{ scheduleLabel(schedule) }}
+                                <span class="mx-1.5">·</span>
+                                Retain {{ schedule.retention_count }}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <Badge :variant="schedule.is_enabled ? 'default' : 'outline'">
+                            {{ schedule.is_enabled ? 'Enabled' : 'Disabled' }}
+                        </Badge>
+                        <ChevronRight
+                            class="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                        />
+                    </div>
+                </Link>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/pages/servers/Show.vue
+++ b/resources/js/pages/servers/Show.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue';
-import { Head, router, useForm } from '@inertiajs/vue3';
+import { Head, Link, router, useForm } from '@inertiajs/vue3';
 import {
     Server,
     CheckCircle2,
@@ -13,8 +12,11 @@ import {
     Activity,
     Info,
     Trash2,
+    Calendar,
+    Plus,
 } from 'lucide-vue-next';
-import AppLayout from '@/layouts/AppLayout.vue';
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
+import InputError from '@/components/InputError.vue';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -27,9 +29,31 @@ import {
     DialogTrigger,
     DialogClose,
 } from '@/components/ui/dialog';
-import { index as serversIndex, show as serversShow, destroy as serversDestroy } from '@/routes/servers';
-import type { BreadcrumbItem } from '@/types';
+import { Input } from '@/components/ui/input';
+import AppLayout from '@/layouts/AppLayout.vue';
 import { STEP_LABELS, STEP_KEYS } from '@/lib/provision-steps';
+import { index as backupDestinationsIndex } from '@/routes/backup-destinations';
+import { index as serversIndex, show as serversShow, destroy as serversDestroy } from '@/routes/servers';
+import { store as backupSchedulesStore, destroy as backupSchedulesDestroy } from '@/routes/servers/backup-schedules';
+import type { BreadcrumbItem } from '@/types';
+
+interface BackupScheduleRow {
+    id: number;
+    backup_destination_id: number;
+    destination_name: string;
+    frequency: string;
+    time: string;
+    day_of_week: number | null;
+    day_of_month: number | null;
+    retention_count: number;
+    is_enabled: boolean;
+    created_at: string;
+}
+
+interface BackupDestinationOption {
+    id: number;
+    name: string;
+}
 
 interface ProvisionStep {
     step: string;
@@ -53,6 +77,8 @@ interface ServerDetail {
 
 const props = defineProps<{
     server: ServerDetail;
+    backupSchedules: BackupScheduleRow[];
+    backupDestinations: BackupDestinationOption[];
 }>();
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -80,7 +106,10 @@ const isPending = computed(() => props.server.status === 'pending');
 const isFailed = computed(() => props.server.status === 'failed');
 
 function startPolling() {
-    if (pollInterval) return;
+    if (pollInterval) {
+return;
+}
+
     pollInterval = setInterval(() => {
         router.reload({ only: ['server'] });
     }, 3000);
@@ -104,7 +133,6 @@ onUnmounted(() => {
 });
 
 // Watch for status change — stop polling when done
-import { watch } from 'vue';
 watch(
     () => props.server.status,
     (status) => {
@@ -155,16 +183,26 @@ function formatTime(iso: string): string {
 
 // The index of the last logged step (by log order, not step order) — supports re-runs
 const lastCompletedIndex = computed(() => {
-    if (isProvisioned.value) return STEP_KEYS.length - 1;
+    if (isProvisioned.value) {
+return STEP_KEYS.length - 1;
+}
+
     for (let i = props.server.provision_log.length - 1; i >= 0; i--) {
         const idx = STEP_KEYS.indexOf(props.server.provision_log[i].step);
-        if (idx !== -1) return idx;
+
+        if (idx !== -1) {
+return idx;
+}
     }
+
     return -1;
 });
 
 function isStepCompleted(index: number): boolean {
-    if (isProvisioned.value) return true;
+    if (isProvisioned.value) {
+return true;
+}
+
     // A step is completed if a later or equal step was logged
     return index <= lastCompletedIndex.value;
 }
@@ -175,10 +213,17 @@ const hasStarted = computed(() =>
 );
 
 function isStepActive(index: number): boolean {
-    if (isProvisioned.value) return false;
-    if (!hasStarted.value) return false;
+    if (isProvisioned.value) {
+return false;
+}
+
+    if (!hasStarted.value) {
+return false;
+}
+
     // Show spinner on the step right after the last completed one
     const nextIndex = lastCompletedIndex.value + 1;
+
     return index === nextIndex && index < STEP_KEYS.length;
 }
 
@@ -187,15 +232,92 @@ const completedStepKeys = computed(
 );
 
 const progressPercent = computed(() => {
-    if (isProvisioned.value) return 100;
-    if (isPending.value) return 0;
+    if (isProvisioned.value) {
+return 100;
+}
+
+    if (isPending.value) {
+return 0;
+}
+
     const done = STEP_KEYS.filter((k) => completedStepKeys.value.has(k)).length;
+
     return Math.round((done / STEP_KEYS.length) * 100);
 });
 
 function stepTimestamp(key: string): string | null {
     const entry = props.server.provision_log.find((l) => l.step === key);
+
     return entry ? formatTime(entry.timestamp) : null;
+}
+
+// ── Backup schedules ─────────────────────────────────────────
+const showAddScheduleModal = ref(false);
+const showNoDestinationsDialog = ref(false);
+const showDeleteScheduleDialog = ref(false);
+const scheduleToDelete = ref<BackupScheduleRow | null>(null);
+
+const scheduleForm = useForm({
+    backup_destination_id: '',
+    frequency: 'daily',
+    time: '02:00',
+    day_of_week: 0,
+    day_of_month: 1,
+    retention_count: 7,
+});
+
+function handleAddSchedule() {
+    if (props.backupDestinations.length === 0) {
+        showNoDestinationsDialog.value = true;
+    } else {
+        showAddScheduleModal.value = true;
+    }
+}
+
+function submitAddSchedule() {
+    scheduleForm.post(backupSchedulesStore(props.server.id).url, {
+        onSuccess: () => {
+            showAddScheduleModal.value = false;
+            scheduleForm.reset();
+        },
+    });
+}
+
+const deleteScheduleForm = useForm({});
+
+function confirmDeleteSchedule(schedule: BackupScheduleRow) {
+    scheduleToDelete.value = schedule;
+    showDeleteScheduleDialog.value = true;
+}
+
+function deleteSchedule() {
+    if (!scheduleToDelete.value) {
+return;
+}
+
+    deleteScheduleForm.delete(
+        backupSchedulesDestroy({ server: props.server.id, backup_schedule: scheduleToDelete.value.id }).url,
+        {
+            onSuccess: () => {
+                showDeleteScheduleDialog.value = false;
+                scheduleToDelete.value = null;
+            },
+        },
+    );
+}
+
+const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function scheduleLabel(schedule: BackupScheduleRow): string {
+    if (schedule.frequency === 'weekly' && schedule.day_of_week !== null) {
+        return `Weekly on ${dayNames[schedule.day_of_week]} at ${schedule.time}`;
+    }
+
+    if (schedule.frequency === 'monthly' && schedule.day_of_month !== null) {
+        return `Monthly on day ${schedule.day_of_month} at ${schedule.time}`;
+    }
+
+    return `Daily at ${schedule.time}`;
 }
 
 // ── Delete server ────────────────────────────────────────────
@@ -489,7 +611,233 @@ function deleteServer() {
                         </div>
                     </div>
                 </div>
+
+                <!-- Backup Schedules -->
+                <div
+                    class="overflow-hidden rounded-xl border border-sidebar-border/70 bg-card dark:border-sidebar-border"
+                >
+                    <div
+                        class="flex items-center gap-3 border-b border-sidebar-border/70 px-5 py-4 dark:border-sidebar-border"
+                    >
+                        <Calendar class="size-5 shrink-0 text-muted-foreground" />
+                        <p class="text-sm font-medium">Backup Schedules</p>
+                        <span class="ml-auto">
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                @click="handleAddSchedule"
+                            >
+                                <Plus class="size-3.5" />
+                                Add Schedule
+                            </Button>
+                        </span>
+                    </div>
+
+                    <div v-if="backupSchedules.length === 0" class="px-5 py-8 text-center text-sm text-muted-foreground">
+                        <template v-if="backupDestinations.length === 0">
+                            Create a backup destination first to schedule backups.
+                        </template>
+                        <template v-else>
+                            No backup schedules configured for this server.
+                        </template>
+                    </div>
+
+                    <div v-else class="divide-y divide-sidebar-border/50 dark:divide-sidebar-border/30">
+                        <div
+                            v-for="schedule in backupSchedules"
+                            :key="schedule.id"
+                            class="flex items-center justify-between px-5 py-3"
+                        >
+                            <div>
+                                <p class="text-sm font-medium">{{ schedule.destination_name }}</p>
+                                <p class="mt-0.5 text-xs text-muted-foreground">
+                                    {{ scheduleLabel(schedule) }}
+                                    <span class="mx-1.5">·</span>
+                                    Retain {{ schedule.retention_count }} backups
+                                </p>
+                            </div>
+                            <div class="flex items-center gap-2">
+                                <Badge :variant="schedule.is_enabled ? 'default' : 'outline'">
+                                    {{ schedule.is_enabled ? 'Enabled' : 'Disabled' }}
+                                </Badge>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    class="size-7 text-muted-foreground hover:text-destructive"
+                                    @click="confirmDeleteSchedule(schedule)"
+                                >
+                                    <Trash2 class="size-3.5" />
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </template>
+
+            <!-- Add Schedule Modal -->
+            <Dialog v-model:open="showAddScheduleModal">
+                <DialogContent class="sm:max-w-md">
+                    <DialogHeader>
+                        <DialogTitle>Add Backup Schedule</DialogTitle>
+                        <DialogDescription>
+                            Configure when this server should be backed up.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <form
+                        @submit.prevent="submitAddSchedule"
+                        class="flex flex-col gap-4 py-2"
+                    >
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium" for="schedule-dest">Backup Destination</label>
+                            <select
+                                id="schedule-dest"
+                                v-model="scheduleForm.backup_destination_id"
+                                :disabled="scheduleForm.processing"
+                                class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                <option value="">Select destination</option>
+                                <option
+                                    v-for="dest in backupDestinations"
+                                    :key="dest.id"
+                                    :value="dest.id"
+                                >
+                                    {{ dest.name }}
+                                </option>
+                            </select>
+                            <InputError :message="scheduleForm.errors.backup_destination_id" />
+                        </div>
+
+                        <div class="grid grid-cols-2 gap-4">
+                            <div class="flex flex-col gap-1.5">
+                                <label class="text-sm font-medium" for="schedule-frequency">Frequency</label>
+                                <select
+                                    id="schedule-frequency"
+                                    v-model="scheduleForm.frequency"
+                                    :disabled="scheduleForm.processing"
+                                    class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    <option value="daily">Daily</option>
+                                    <option value="weekly">Weekly</option>
+                                    <option value="monthly">Monthly</option>
+                                </select>
+                                <InputError :message="scheduleForm.errors.frequency" />
+                            </div>
+
+                            <div class="flex flex-col gap-1.5">
+                                <label class="text-sm font-medium" for="schedule-time">Time</label>
+                                <Input
+                                    id="schedule-time"
+                                    v-model="scheduleForm.time"
+                                    type="time"
+                                    :disabled="scheduleForm.processing"
+                                />
+                                <InputError :message="scheduleForm.errors.time" />
+                            </div>
+                        </div>
+
+                        <div v-if="scheduleForm.frequency === 'weekly'" class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium" for="schedule-dow">Day of Week</label>
+                            <select
+                                id="schedule-dow"
+                                v-model.number="scheduleForm.day_of_week"
+                                :disabled="scheduleForm.processing"
+                                class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                <option v-for="(name, idx) in dayNames" :key="idx" :value="idx">
+                                    {{ name }}
+                                </option>
+                            </select>
+                            <InputError :message="scheduleForm.errors.day_of_week" />
+                        </div>
+
+                        <div v-if="scheduleForm.frequency === 'monthly'" class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium" for="schedule-dom">Day of Month</label>
+                            <Input
+                                id="schedule-dom"
+                                v-model.number="scheduleForm.day_of_month"
+                                type="number"
+                                min="1"
+                                max="28"
+                                :disabled="scheduleForm.processing"
+                            />
+                            <InputError :message="scheduleForm.errors.day_of_month" />
+                        </div>
+
+                        <div class="flex flex-col gap-1.5">
+                            <label class="text-sm font-medium" for="schedule-retention">Retention count</label>
+                            <Input
+                                id="schedule-retention"
+                                v-model.number="scheduleForm.retention_count"
+                                type="number"
+                                min="1"
+                                max="365"
+                                :disabled="scheduleForm.processing"
+                            />
+                            <InputError :message="scheduleForm.errors.retention_count" />
+                        </div>
+
+                        <DialogFooter class="pt-2">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                @click="showAddScheduleModal = false"
+                                :disabled="scheduleForm.processing"
+                            >
+                                Cancel
+                            </Button>
+                            <Button type="submit" :disabled="scheduleForm.processing">
+                                <Loader2
+                                    v-if="scheduleForm.processing"
+                                    class="size-4 animate-spin"
+                                />
+                                Create Schedule
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            <!-- No Destinations Dialog -->
+            <Dialog v-model:open="showNoDestinationsDialog">
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>No backup destinations</DialogTitle>
+                        <DialogDescription>
+                            You need to create a backup destination before you can schedule backups. Backup destinations define where your backups are stored.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" @click="showNoDestinationsDialog = false">Cancel</Button>
+                        <Link :href="backupDestinationsIndex()">
+                            <Button>Go to Backup Destinations</Button>
+                        </Link>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <!-- Delete Schedule Confirmation -->
+            <Dialog v-model:open="showDeleteScheduleDialog">
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete backup schedule</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to remove this backup schedule? This action cannot be undone.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" @click="showDeleteScheduleDialog = false">Cancel</Button>
+                        <Button
+                            variant="destructive"
+                            :disabled="deleteScheduleForm.processing"
+                            @click="deleteSchedule"
+                        >
+                            <Loader2 v-if="deleteScheduleForm.processing" class="size-4 animate-spin" />
+                            Delete schedule
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     </AppLayout>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\BackupDestinationController;
+use App\Http\Controllers\BackupScheduleController;
+use App\Http\Controllers\BackupScheduleIndexController;
 use App\Http\Controllers\ServerController;
 use App\Http\Controllers\ServerProvisionCallbackController;
 use App\Http\Controllers\SiteController;
@@ -18,6 +21,18 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('servers.generate-name');
 
     Route::resource('servers', ServerController::class)
+        ->only(['index', 'store', 'show', 'destroy']);
+
+    Route::get('backup-schedules', BackupScheduleIndexController::class)
+        ->name('backup-schedules.index');
+
+    Route::resource('servers.backup-schedules', BackupScheduleController::class)
+        ->only(['store', 'destroy']);
+
+    Route::get('backup-destinations/generate-name', [BackupDestinationController::class, 'generateName'])
+        ->name('backup-destinations.generate-name');
+
+    Route::resource('backup-destinations', BackupDestinationController::class)
         ->only(['index', 'store', 'show', 'destroy']);
 
     Route::resource('sites', SiteController::class)


### PR DESCRIPTION
## Summary
- **Backup Destinations** — CRUD for remote storage locations (e.g. Borg storage boxes) with encrypted credentials, list/show pages, add/delete modals, and auto-generated names
- **Backup Schedules** — per-server schedule configuration (daily/weekly/monthly) with destination picker, retention count, and enable/disable; standalone overview page listing all schedules across servers
- **Sidebar** — new "Backups" nav section with Destinations and Schedules entries; NavMain now accepts a `label` prop for section titles
- **Server Show** — backup schedules card (provisioned servers only) with add/delete; informational dialog when no destinations exist yet

## Test plan
- [ ] Run `php artisan migrate` — two new tables created
- [ ] Visit `/backup-destinations` — empty state renders, add modal works with auto-generated name
- [ ] Create a destination, verify show page with connection details and delete confirmation
- [ ] Visit `/backup-schedules` — empty state renders
- [ ] Visit a provisioned server — backup schedules card visible, "Add Schedule" opens informational dialog (no destinations) or add form (with destinations)
- [ ] Create a schedule, verify it appears on server show page and schedules overview
- [ ] Delete a schedule, verify removal
- [ ] Sidebar shows "Platform" and "Backups" sections with correct icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)