### PR TITLE
Harden production container and web server security

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -113,7 +113,7 @@ COPY --from=assets --chown=www-data:www-data /app/public/build /var/www/html/pub
 # Ensure storage and cache dirs exist with correct permissions
 RUN mkdir -p storage/logs storage/framework/cache storage/framework/sessions storage/framework/views bootstrap/cache \
     && chown -R www-data:www-data storage bootstrap/cache \
-    && chmod -R 775 storage bootstrap/cache
+    && chmod -R 750 storage bootstrap/cache
 
 # Create directory for PHP-FPM socket/pid
 RUN mkdir -p /run/php

--- a/docker/production/docker-compose.prod.yml
+++ b/docker/production/docker-compose.prod.yml
@@ -14,6 +14,14 @@ services:
       - traefik.http.routers.sword.entrypoints=websecure
       - traefik.http.routers.sword.tls.certresolver=letsencrypt
       - traefik.http.services.sword.loadbalancer.server.port=8080
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/login"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    security_opt:
+      - no-new-privileges:true
 
   redis:
     image: redis:alpine
@@ -22,6 +30,13 @@ services:
     command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
     networks:
       - sword_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    security_opt:
+      - no-new-privileges:true
 
 networks:
   sword_network:

--- a/docker/production/nginx.conf
+++ b/docker/production/nginx.conf
@@ -1,3 +1,5 @@
+server_tokens off;
+
 server {
     listen 8080 default_server;
     server_name _;
@@ -8,6 +10,16 @@ server {
     charset utf-8;
 
     client_max_body_size 100M;
+    client_body_timeout 30s;
+    client_header_timeout 30s;
+    send_timeout 30s;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;
@@ -26,6 +38,7 @@ server {
         fastcgi_param HTTP_X_FORWARDED_PROTO $http_x_forwarded_proto;
         fastcgi_param HTTP_X_FORWARDED_FOR $http_x_forwarded_for;
         fastcgi_param HTTP_X_FORWARDED_HOST $http_x_forwarded_host;
+        fastcgi_read_timeout 60s;
     }
 
     location ~ /\.(?!well-known).* {

--- a/docker/production/php-fpm.conf
+++ b/docker/production/php-fpm.conf
@@ -9,6 +9,6 @@ pm.max_children = 20
 pm.start_servers = 5
 pm.min_spare_servers = 2
 pm.max_spare_servers = 10
-pm.max_requests = 500
+pm.max_requests = 10000
 
-clear_env = no
+clear_env = yes


### PR DESCRIPTION
## Summary
- Add Nginx security headers (X-Frame-Options, HSTS, X-Content-Type-Options, XSS-Protection, Referrer-Policy)
- Disable Nginx server_tokens and add request/response timeouts
- Set PHP-FPM `clear_env=yes` to prevent environment variable leakage
- Tighten storage directory permissions from 775 to 750
- Add container health checks for app and Redis
- Add `no-new-privileges` security option to containers

## Test plan
- [ ] Rebuild Docker image with updated configs
- [ ] Verify security headers present with `curl -I https://<domain>`
- [ ] Verify `server_tokens` is off (no Nginx version in headers)
- [ ] Verify health checks are working: `docker inspect --format='{{.State.Health}}' sword_app`
- [ ] Verify app still loads correctly after `clear_env=yes` change